### PR TITLE
Add github action to build JB

### DIFF
--- a/.github/workflows/deploy_jupyterbook.yml
+++ b/.github/workflows/deploy_jupyterbook.yml
@@ -1,0 +1,36 @@
+name: Build and Deploy Jupyter Book
+on:
+  push:
+    branches:    
+      - master
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+
+      - name: Setup Miniconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          activate-environment: taxcalc-dev
+          environment-file: environment.yml
+          python-version: 3.7
+          auto-activate-base: false
+
+      - name: Build # Build Jupyter Book
+        shell: bash -l {0}
+        run: |
+          pip install jupyter-book
+          conda install -c pslmodels behresp
+          cd docs
+          jb build .
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: jb_git_tutorial/_build/html # The folder the action should deploy.


### PR DESCRIPTION
This PR adds a github action to build the Tax-Calculator Jupyter Book and push it to `Tax-Calculator:gh-pages`.

Note that this action installs `jupyter-book` and `behresp` to the `taxcalc-dev` environment when building the book since both are needed in building the book.  Note that since `behresp` is necessary to run some of the Tax-Calculator recipes, I think it'd might be advisable to make `behresp` a dependency of Tax-Calculator, but TC developers like @matthjensen should decide this.
